### PR TITLE
CallButtons: Prevent FRP bypass via the video calling option

### DIFF
--- a/src/com/android/incallui/CallButtonPresenter.java
+++ b/src/com/android/incallui/CallButtonPresenter.java
@@ -32,6 +32,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.ResultReceiver;
+import android.provider.Settings;
 import android.telecom.CallAudioState;
 import android.telecom.InCallService.VideoCall;
 import android.telecom.PhoneAccount;
@@ -60,6 +61,8 @@ import com.cyanogen.ambient.incall.InCallServices;
 import com.cyanogen.ambient.incall.extension.OriginCodes;
 import com.cyanogen.ambient.incall.extension.StatusCodes;
 import com.cyanogen.ambient.incall.extension.StartCallRequest;
+
+import cyanogenmod.providers.CMSettings;
 
 import java.util.List;
 import java.util.Objects;
@@ -578,6 +581,13 @@ public class CallButtonPresenter extends Presenter<CallButtonPresenter.CallButto
                 QtiCallUtils.hasVoiceCapabilities(mCall));
     }
 
+    private boolean isDeviceProvisionedInSettingsDb(Context context) {
+        return (CMSettings.Secure.getInt(context.getContentResolver(),
+                CMSettings.Secure.CM_SETUP_WIZARD_COMPLETED, 0) != 0)
+                && (Settings.Global.getInt(context.getContentResolver(),
+                Settings.Global.DEVICE_PROVISIONED, 0) != 0);
+    }
+
     /**
      * Updates the buttons applicable for the UI.
      *
@@ -609,7 +619,8 @@ public class CallButtonPresenter extends Presenter<CallButtonPresenter.CallButto
                 (QtiCallUtils.hasVideoCapabilities(call) ||
                         QtiCallUtils.hasVoiceCapabilities(call) ||
                         (contactInCallPlugins != null && !contactInCallPlugins.isEmpty())) &&
-                (callState == Call.State.ACTIVE || callState == Call.State.ONHOLD);
+                (callState == Call.State.ACTIVE || callState == Call.State.ONHOLD)
+                && isDeviceProvisionedInSettingsDb(ui.getContext());
 
         final boolean showMute = call.can(android.telecom.Call.Details.CAPABILITY_MUTE);
         final boolean showAddParticipant = call.can(


### PR DESCRIPTION
When OOBE is open, phone calls can be placed to the device.
The incall dialog feature to change to a video call is exploitable
via the dialogs that it creates.

Check to ensure that the device is provisioned by us before showing
this button.

Change-Id: I49db4df359118a8ea4194b94abf9024fd32064d5