### PR TITLE
Stops ModButtonPresenter from hitting PackageManager on UI updates.

### DIFF
--- a/src/com/android/incallui/ModButtonPresenter.java
+++ b/src/com/android/incallui/ModButtonPresenter.java
@@ -400,9 +400,7 @@ public class ModButtonPresenter extends Presenter<ModButtonPresenter.ModButtonUi
         List<InCallPluginInfo> contactInCallPlugins = getContactInCallPluginInfoList();
         final boolean shouldShowInCall = isProvisioned &&
                 contactInCallPlugins != null && !contactInCallPlugins.isEmpty();
-        final boolean showNote = isProvisioned &&
-                DeepLinkIntegrationManager.getInstance().ambientIsAvailable(getUi().getContext()) &&
-                        mNoteDeepLink != null;
+        final boolean showNote = isProvisioned && mNoteDeepLink != null;
 
         ui.showButton(BUTTON_INCALL, shouldShowInCall);
         if (shouldShowInCall) {


### PR DESCRIPTION
This call was causing a lot of log spam on devices without Core, and
may have been contributing a slow down in showing the Call UI.

NOTES-150

Change-Id: Ica37627f22673d5f521e2be164ed05e709bf216f