### PR TITLE
Explicitly set the visibility of right_icon within call notification

### DIFF
--- a/src/com/android/incallui/StatusBarNotifier.java
+++ b/src/com/android/incallui/StatusBarNotifier.java
@@ -41,6 +41,7 @@ import android.telephony.SubscriptionManager;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 
+import android.view.View;
 import android.widget.RemoteViews;
 import com.android.contacts.common.util.BitmapUtil;
 import com.android.incallui.ContactInfoCache.ContactCacheEntry;
@@ -316,7 +317,7 @@ public class StatusBarNotifier implements InCallPresenter.InCallStateListener,
                 notification.headsUpContentView};
         // add LookupProvider badge to Notification
         Drawable logo = contactInfo.lookupProviderBadge;
-        if (largeIcon != null && logo != null) {
+        if (logo != null) {
             Bitmap bitmap = null;
             if (logo instanceof BitmapDrawable) {
                 bitmap = ((BitmapDrawable) logo).getBitmap();
@@ -330,6 +331,7 @@ public class StatusBarNotifier implements InCallPresenter.InCallStateListener,
             int spamColor = mContext.getResources().getColor(R.color.spam_contact_color);
             for (RemoteViews view : viewsToUpdate) {
                 int rightIconId = getNotificationRightIconId(mContext);
+                view.setViewVisibility(rightIconId, View.VISIBLE);
                 view.setImageViewBitmap(rightIconId, bitmap);
                 view.setViewPadding(rightIconId, 0, 0, 0, 0);
                 if (contactInfo.isSpam) {


### PR DESCRIPTION
The right icon within the notification at times had the wrong visibility
state. This led to the contact attribution badge not showing up at times.
This could be the result of a series of notification state updates due to
the state change callbacks via ContactInfoCache. Resorting to explicitly
updating the view's visibility.

Change-Id: I447a1a4dc08ee8b6bba5569c7a1bb91d7677bd15
Issue-Id: OPO-766