### PR TITLE
[Glowpad] Remove marginBottom

### DIFF
--- a/res/layout/answer_fragment.xml
+++ b/res/layout/answer_fragment.xml
@@ -25,7 +25,6 @@
         android:layout_centerHorizontal="true"
         android:gravity="center"
         android:background="@color/glowpad_background_color"
-        android:layout_marginBottom="@dimen/glowpadview_margin_bottom"
 
         dc:targetDrawables="@array/incoming_call_widget_audio_with_sms_without_block_targets"
         dc:targetDescriptions="@array/incoming_call_widget_audio_with_sms_without_block_target_descriptions"


### PR DESCRIPTION
On smaller devices this moves the glowpad too far
down, resulting in the bottom of the block target
to be cut off by any softkeys. Instead, glowpad
should figure out its placement according to gravity.

Glowpad don't need no marginBottom telling it
how to live its life.

Ticket: CYNGNOS-3119
Change-Id: Ic5584a47f7d94c7c3291a8e963413c7e9e4062c4
(cherry picked from commit 9eb99c11b7162e6ee130bec2f72d94ec17ee476f)